### PR TITLE
Allow wildcard password in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -615,6 +615,10 @@ function setupReadlineDebugger () {
 }
 
 server.listen(PORT, () => {
+    if (PASSWORD === '*') {
+        console.log('WARNING: The password in the config is set to a wildcard. Any password will be accepted.')
+    }
+    
     console.log(`Host: http://localhost:${PORT}`)
     console.log('Routes:')
     printRoutes(app)

--- a/index.js
+++ b/index.js
@@ -81,16 +81,27 @@ for (const route of ['/', '/login', '/table', '/banner', '/popup', '/outro']) {
 
 app.post('/auth', (req, res) => {
     const { password } = req.body
+
+    // If the password is set to a wildcard, allow access no matter what
+    if (PASSWORD === '*') {
+        res.send({
+            isValid: true,
+            token: PASSWORD
+        })
+        return
+    }
+
     if (password === PASSWORD) {
         res.send({
             isValid: true,
             token: PASSWORD // stored in localStorage
         })
-    } else {
-        res.send({
-            isValid: false
-        })
+        return
     }
+
+    res.send({
+        isValid: false
+    })
 })
 
 app.get('/twitch', async (_req, res) => {


### PR DESCRIPTION
This lets a user set the password in `config.json` to `*`, which will make the password effectively not matter and communicate to the frontend that a valid password has been sent.

A warning will be printed on each boot of the server when this configuration is used due to the obvious security risk of letting the server accept any password.